### PR TITLE
Upgrade earmark to 1.4.48

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {erl_opts, [debug_info]}.
 
 {deps, [
-    {earmark, "1.4.47"},
+    {earmark, "1.4.48"},
     {nimble_csv, "1.2.0"}
 ]}.


### PR DESCRIPTION
earmark 1.4.48 fixes OTP28 build.

This is needed in order to build erlang-red with Erlang/OTP 28. Otherwise, this error happens:

https://github.com/pragdave/earmark/commit/0cc7032f28a6cb4bce1036d7b7c8553a15ef5700